### PR TITLE
#169817831 Marking all notifications as read

### DIFF
--- a/src/controllers/notification.controller.js
+++ b/src/controllers/notification.controller.js
@@ -40,5 +40,27 @@ class NotificationController {
     await UserService.updateUser(req.user.email, { appNotification, emailNotification });
     return response.successMessage(res, 'Successfully update user preference.', 200);
   }
+
+  /**
+   * Update all notifications as read
+   * @param {Object} req The request object
+   * @param {Object} res The response object
+   * @returns {Promise} res
+   */
+  static async updateNotificationsStatus(req, res) {
+    await NotificationService.updateNotifications({ receiver: req.user.id, read: false }, { read: true });
+    return response.successMessage(res, 'Successfully marked all notifications as read.', 200);
+  }
+
+  /**
+   * Update a notification as read
+   * @param {Object} req The request object
+   * @param {Object} res The response object
+   * @returns {Promise} res
+   */
+  static async updateNotificationStatus(req, res) {
+    await NotificationService.updateNotifications({ id: req.params.notificationID, receiver: req.user.id }, { read: req.body.isRead });
+    return response.successMessage(res, 'Successfully marked a notification as read.', 200);
+  }
 }
 export default NotificationController;

--- a/src/helpers/validate.helper.js
+++ b/src/helpers/validate.helper.js
@@ -80,5 +80,15 @@ class Validate {
       check('emailNotification', 'Email notification need to be boolean').isBoolean()
     ];
   }
+
+  /**
+   * Validate when updating notification
+   * @returns {[{ValidationChain}]}.
+   */
+  static validateOnUpdateNotification() {
+    return [
+      check('isRead', 'isRead needs to be a boolean').isBoolean(),
+    ];
+  }
 }
 export default Validate;

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -14,6 +14,11 @@
         socket.on('approve-or-reject-trip_request_event', function (data) {
             console.log(data);
         });
+
+        socket.emit('connect_user', 198);
+        socket.on('trip_request_event', function (data) {
+            console.log(data);
+        });
     </script>
 </body>
 </html>

--- a/src/routes/notification.route.js
+++ b/src/routes/notification.route.js
@@ -87,4 +87,45 @@ router.get('/:id', verifyToken.headerToken, notificationController.getNotificati
  *            type: string
  */
 router.patch('/changePreference', Validate.userPreference(), isValid, verifyToken.headerToken, notificationController.changePreference);
+/**
+ * @swagger
+ *
+ * /notifications:
+ *    patch:
+ *      summary: Mark all notifications as read
+ *      tags: [Notification]
+ *      parameters:
+ *       - name: token
+ *         in: header
+ *         description: Check authentication
+ *         required: true
+ *         type: string
+ *      responses:
+ *        "200":
+ *          description: Successfully marked all notifications as read.
+ */
+router.patch('/', Validate.validateOnUpdateNotification(), isValid, verifyToken.headerToken, notificationController.updateNotificationsStatus);
+/**
+ * @swagger
+ *
+ * /notifications/{id}:
+ *    patch:
+ *      summary: Mark a notification as read
+ *      tags: [Notification]
+ *      parameters:
+ *       - name: token
+ *         in: header
+ *         description: Check authentication
+ *         required: true
+ *         type: string
+ *       - name: id
+ *         in: path
+ *         description: Notification id
+ *         required: true
+ *         type: string
+ *      responses:
+ *        "200":
+ *          description: Successfully marked a notification as read.
+ */
+router.patch('/:notificationID', Validate.validateOnUpdateNotification(), isValid, verifyToken.headerToken, notificationController.updateNotificationStatus);
 export default router;

--- a/src/services/notification.service.js
+++ b/src/services/notification.service.js
@@ -72,5 +72,16 @@ class NotificationService {
     const query = await db.notification.findOne({ where });
     if (query) return query;
   }
+
+  /**
+   * update notifications
+   * @param { Object } where example: `{ receiver, userId }`.
+   * @param { Object } data example: `{ read: true }`.
+   * @returns { Promise } Returns a notification query result object.
+   */
+  static async updateNotifications(where, data) {
+    const query = await db.notification.update(data, { where });
+    return query;
+  }
 }
 export default NotificationService;

--- a/src/tests/znotification.test.js
+++ b/src/tests/znotification.test.js
@@ -15,6 +15,7 @@ const token1 = GenerateToken({ email: 'shemhdsnbad@gmail.com', isVerified: 'true
 describe('Notification Tests', () => {
   before(async () => {
     await db.user.destroy({ where: {}, force: true });
+    await db.notification.destroy({ where: {}, force: true });
     await db.user.create({
       id: 198,
       firstName: 'Veda',
@@ -72,6 +73,24 @@ describe('Notification Tests', () => {
       id: 120,
       userId: 298,
       managerId: 198
+    });
+    await db.notification.create({
+      receiver: 198,
+      requestId: 9,
+      title: 'New requests',
+      message: 'New request'
+    });
+    await db.notification.create({
+      receiver: 198,
+      requestId: 9,
+      title: 'New requests',
+      message: 'New request'
+    });
+    await db.notification.create({
+      receiver: 198,
+      requestId: 9,
+      title: 'New requests',
+      message: 'New request'
     });
     const socketURL = 'http://localhost:3000';
 
@@ -131,6 +150,28 @@ describe('Notification Tests', () => {
       .end((err, res) => {
         res.should.have.status(200);
         chai.expect(res.body.message).eql('Successfully update user preference.');
+        done();
+      });
+  });
+  it('should mark a notification as read', (done) => {
+    chai.request(app)
+      .patch(`/api/v1/notifications/${2}`)
+      .set('token', `Bearer ${token}`)
+      .send({ isRead: true })
+      .end((err, res) => {
+        res.should.have.status(200);
+        chai.expect(res.body.message).eql('Successfully marked a notification as read.');
+        done();
+      });
+  });
+  it('should mark all notifications to read', (done) => {
+    chai.request(app)
+      .patch('/api/v1/notifications')
+      .set('token', `Bearer ${token}`)
+      .send({ isRead: true })
+      .end((err, res) => {
+        res.should.have.status(200);
+        chai.expect(res.body.message).eql('Successfully marked all notifications as read.');
         done();
       });
   });


### PR DESCRIPTION
#### What does this PR do?

This PR adds an option to mark all notifications as read.
Users may want to tidy up their notification panel.

#### Description of Task to be completed?
**As user,** I should be able to mark all my notifications as read
**So that,** I can keep my notifications panel clean

Given that the user is logged in, then when the user clicks on ‘Mark all as read’ the notification icon count should change to the bell component with no number attached to it.

#### How should this be manually tested?

- After clone repository, go to the root of the project open path into command run the `npm install` and once setup is done click `npm test`.

- In Postman, create a PATCH request with this url:`localhost:3000/api/v1/notifications/read` and pass `token` in headers
#### Screenshots

#### What are the relevant pivotal tracker stories?
- [#169817831](https://www.pivotaltracker.com/story/show/169817831)