### PR TITLE
#170752560 fix bug in trip request and add limit, descending order in get comment endpoint

### DIFF
--- a/src/controllers/trip.controller.js
+++ b/src/controllers/trip.controller.js
@@ -188,8 +188,8 @@ class TripController {
   static async getAllComments(req, res) {
     const subjectType = 'trip request';
     const subjectID = req.params.tripRequestID;
-    const { page } = req.query;
-    const limitNumber = 10;
+    const { page, limit } = req.query;
+    const limitNumber = (/[0-9]/g.test(limit)) ? limit : 10;
     const offset = Paginate(page, limitNumber);
     const data = await commentService.getAllCommets(subjectID, subjectType, limitNumber, offset);
     if (data) return response.successMessage(res, 'success', 200, data);

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -9,7 +9,7 @@
 <body>
     <script src="/socket.io/socket.io.js"></script>
     <script>
-        var socket = io.connect('http://localhost:3000');
+        var socket = io.connect('https://blackninjas-backend-staging.herokuapp.com');
         socket.emit('connect_user', 3);
         socket.on('approve-or-reject-trip_request_event', function (data) {
             console.log(data);

--- a/src/services/Queries.js
+++ b/src/services/Queries.js
@@ -186,6 +186,9 @@ class Queries {
         where:
           managerId,
         group: table.status,
+        order: [
+          ['createdAt', 'DESC']
+        ],
         limit,
         offset
       });

--- a/src/services/trip.services.js
+++ b/src/services/trip.services.js
@@ -42,7 +42,7 @@ class TripService {
    */
   static async findRequestByID(table, tripId) {
     try {
-      const requestedTrip = await Queries.findAllRecord(table, db.requesttrip, tripId);
+      const requestedTrip = await Queries.findAllRecord(table, tripId);
       return requestedTrip;
     } catch (error) {
       return error;

--- a/src/tests/comment.test.js
+++ b/src/tests/comment.test.js
@@ -88,7 +88,7 @@ describe('comment tests', () => {
   it('should display all trip request comments', (done) => {
     chai
       .request(app)
-      .get(`/api/v1/trip-requests/${trip[0].tripId}/comments?page=1`)
+      .get(`/api/v1/trip-requests/${trip[0].tripId}/comments?page=1&limit=2`)
       .set('token', `Bearer ${token}`)
       .end((err, res) => {
         res.should.have.status(200);
@@ -119,7 +119,7 @@ describe('comment tests', () => {
   it('should check if a user allowed to view others comment', (done) => {
     chai
       .request(app)
-      .get(`/api/v1/trip-requests/${trip[0].tripId}/comments?page=1`)
+      .get(`/api/v1/trip-requests/${trip[0].tripId}/comments?page=1&limit=2`)
       .set('token', `Bearer ${anauthorizedToken}`)
       .end((err, res) => {
         res.should.have.status(401);


### PR DESCRIPTION
### What does this PR do?
This PR comes
- to fix a bug that found in creating a one-way trip and round trip request
- to add descending order and limit in get comments endpoint
- add Heroku link for a socket.io

#### Description of Task to be completed?
 **Before**
- to create a one-way trip and round trip was not possible 
- The comments were not sorted  in descending order(date)
- The limit in pagination was constant
- To send notification was not working on Heroku

**After fix**

- Now you can create a one-way trip and round trip
- Comment are sorted in descending order
- Limit in pagination is variable 
- To send a notification is working on Heroku

### How should this be manually tested?

After clone repository goes to the root of the project open path into command run the npm install and once setup is done click npm test.

Using Postman to test endpoints:
after sign in you will get a token
Then
Key: Content-Type value: application/JSON
To test authentication, add this to the header: Bearer <TOKEN>

 *create a trip request endpoint*

using POST request
visit: URL localhost:3000/api/v1/tripRequests/{tripRequestID}
after, you will get a response

*Get comments endpoint*

using GET request
visit: URL localhost:3000/api/v1/trip-requests/{tripRequestID}/comments?page={}&limit={}
after, you will get a response

#### Any background context you want to provide?

Only for someone who has an account

#### What are the relevant pivotal tracker stories?
[#170752560](https://www.pivotaltracker.com/story/show/170752560)
#### Screenshots (if appropriate)
#### Questions:
N/A