### PR TITLE
ch(reset link):change redirect link

### DIFF
--- a/src/helpers/send.email.helper.js
+++ b/src/helpers/send.email.helper.js
@@ -142,7 +142,7 @@ class mailer {
   
               </br>  </br>  </br> </div>
           </div>
-         <a href="${process.env.BASE_URL}/api/v1/auth/resetpassword/${token}" class="Email-wrapper_button" style="cursor: pointer !important; justify-self: center; margin-left: 80px; text-decoration: none; color: white;">Reset Password</a>
+         <a href="${process.env.RESET_PASSWORD_FRONTED}/ResetPassword?resetToken=${token}" class="Email-wrapper_button" style="cursor: pointer !important; justify-self: center; margin-left: 80px; text-decoration: none; color: white;">Reset Password</a>
   
   
       </div>


### PR DESCRIPTION

#### What does this PR do?
When user clicks forgot password receives an email that contains a link to reset email this PR changed the redirect to be the frontend link instead of backend

#### Description of Task to be completed?

- change the redirect link in the sender email helper

#### How should this be manually tested?
- clone the repository
- npm i to install dependencies
- npm run to run the server and run on `localhost:3000/api/vi/auth/forgotpassword` and type there email to receive the link

#### Any background context you want to provide?
- none
#### What are the relevant pivotal tracker stories?
#### Screenshots (if appropriate)
#### Questions: