### PR TITLE
Fix condition to compare dates entered by the user

### DIFF
--- a/src/controllers/trip.controller.js
+++ b/src/controllers/trip.controller.js
@@ -330,8 +330,11 @@ class TripController {
   static async getTripStatistics(req, res) {
     try {
       const { startDate } = req.query;
+      const someDate = new Date(startDate);
+      someDate.setDate(someDate.getDate() + 1);
+      const dateFormated = someDate.toISOString().substr(0, 10);
       const { id, firstName } = req.user;
-      const details = await tripService.findTripsCreatedByuser(id, startDate);
+      const details = await tripService.findTripsCreatedByuser(id, dateFormated);
       const totalNumber = details.reduce((sum, trip) => sum + parseInt(trip.count, 10), 0);
       return response.successMessage(res, `Trip statistics for ${firstName}`, 200, { totalTrips: totalNumber, details });
     } catch (error) {

--- a/src/services/trip.services.js
+++ b/src/services/trip.services.js
@@ -3,11 +3,11 @@ import Queries from './Queries';
 
 /** trip service */
 class TripService {
-/**
-    * creating user query
-    * @param {string} tripsRequest users table in database.
-    * @returns {array} data the data to be returned.
-    */
+  /**
+      * creating user query
+      * @param {string} tripsRequest users table in database.
+      * @returns {array} data the data to be returned.
+      */
   static async CreateTripRequest(tripsRequest) {
     return Queries.create(db.requesttrip, tripsRequest);
   }
@@ -151,7 +151,7 @@ class TripService {
   static async findTripsCreatedByuser(userId, searchDate) {
     try {
       const foundTrips = await db.sequelize.query(
-        `SELECT trips."tripType", count(DISTINCT trips."tripId") from trips where trips."userId" = ${userId} and TO_CHAR (trips."createdAt", 'YYYY-MM-DD') <='${searchDate}' GROUP BY trips."tripType"`,
+        `SELECT trips."tripType", count(DISTINCT trips."tripId") from trips where trips."userId" = ${userId} and trips."createdAt"<='${searchDate}' GROUP BY trips."tripType"`,
         { type: db.sequelize.QueryTypes.SELECT }
       );
       return foundTrips;

--- a/src/tests/0000ztrips.js
+++ b/src/tests/0000ztrips.js
@@ -5,7 +5,9 @@ import dotenv from 'dotenv';
 import app from '../app';
 import GenerateToken from '../helpers/token.helper';
 import db from '../database/models';
-import { tripsData, multiCityData, multiCity, notMultiCity } from './user/tripsData';
+import {
+  tripsData, multiCityData, multiCity, notMultiCity
+} from './user/tripsData';
 import EncryptPassword from '../helpers/Encryptor';
 
 const { expect } = chai;


### PR DESCRIPTION
#### What does this PR do?
Fixes a bug found in the comparison of dates entered by the user
#### Description of Task to be completed?
- change the condition used to check two different dates
#### How should this be manually tested?
- Clone this repo
- make sure you have all the packages installed by typing `npm i` and also make sure you have all the migrations by typing `npm run db-migrate`
- use this route `/api/v1/trip-statistics?startDate={the start date to search from}` and it should bring all the trips created since the date provided
#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
#### Screenshots (if appropriate)
#### Questions: