### PR TITLE
#171860073 fix to retrieve booking info for only a specific trip request and allow use to remove unlike or like on an accommodation.

### DIFF
--- a/src/controllers/accomodation.controller.js
+++ b/src/controllers/accomodation.controller.js
@@ -181,7 +181,7 @@ class Accommodation {
    * @returns {Promise} res
    */
   static async bookAccommodation(req, res) {
-    const query = await accomodationServices.bookAccommodation(req.user.id, req.body.accommodationId, req.body.roomId, req.body.departureDate, req.body.checkoutDate);
+    const query = await accomodationServices.bookAccommodation(req.user.id, req.body.tripId, req.body.accommodationId, req.body.roomId, req.body.departureDate, req.body.checkoutDate);
     return response.successMessage(res, 'Booking was successfully processed', 201, query);
   }
 

--- a/src/database/migrations/20200123094706-add-trip-id-to-booking.js
+++ b/src/database/migrations/20200123094706-add-trip-id-to-booking.js
@@ -1,0 +1,27 @@
+const metadata = (Sequelize) => {
+  return {
+    type: Sequelize.INTEGER,
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+    allowNull: true,
+    references: { model: 'trips', key: 'id' }
+  }
+};
+
+module.exports = {
+    up: (queryInterface, Sequelize) => {
+      return queryInterface.sequelize.transaction((transaction) => {
+        return Promise.all([
+          queryInterface.addColumn('bookings', 'tripid', metadata(Sequelize), { transaction }),
+        ])
+      })
+    },
+
+    down: (queryInterface, Sequelize) => {
+      return queryInterface.sequelize.transaction((transaction) => {
+        return Promise.all([
+          queryInterface.removeColumn('bookings', 'tripid', { transaction }),
+        ])
+      })
+    }
+  }; 

--- a/src/database/models/booking.js
+++ b/src/database/models/booking.js
@@ -2,6 +2,7 @@ module.exports = (sequelize, DataTypes) => {
   const booking = sequelize.define('booking', {
     userid: DataTypes.INTEGER,
     accommodationid: DataTypes.INTEGER,
+    tripid: DataTypes.INTEGER,
     roomid: DataTypes.INTEGER,
     departuredate: DataTypes.DATE,
     checkoutdate: DataTypes.DATE
@@ -9,6 +10,11 @@ module.exports = (sequelize, DataTypes) => {
   booking.associate = (models) => {
     booking.belongsTo(models.user, {
       foreignKey: 'userid',
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
+    });
+    booking.belongsTo(models.trips, {
+      foreignKey: 'tripid',
       onDelete: 'CASCADE',
       onUpdate: 'CASCADE',
     });

--- a/src/helpers/validate.helper.js
+++ b/src/helpers/validate.helper.js
@@ -125,6 +125,7 @@ class Validate {
    */
   static bookingValidation() {
     return [
+      check('tripId', 'tripId needs to be a number').isInt(),
       check('accommodationId', 'accommodationId needs to be a number').isInt(),
       check('roomTypeId', 'roomTypeId needs to be a number').isInt(),
       check('departureDate', 'departureDate needs to be a date format').toDate(),

--- a/src/tests/zzzaccommodation.test.js
+++ b/src/tests/zzzaccommodation.test.js
@@ -16,6 +16,8 @@ describe('Book accommodation Tests', () => {
     await db.user.destroy({ where: {}, force: true });
     await db.accomodationtype.destroy({ where: {}, force: true });
     await db.locations.destroy({ where: {}, force: true });
+    await db.trips.destroy({ where: {}, force: true });
+    await db.requesttrip.destroy({ where: {}, force: true });
     await db.user.create({
       id: 198,
       firstName: 'Veda',
@@ -52,6 +54,11 @@ describe('Book accommodation Tests', () => {
       city: 'Nairobi'
     });
 
+    await db.locations.create({
+      id: 90,
+      city: 'Kigali'
+    });
+
     await db.accomodation.create({
       id: 142,
       name: 'Marriot',
@@ -85,11 +92,27 @@ describe('Book accommodation Tests', () => {
       roomImageUrl: 'roomImage1',
       status: 'available'
     });
+    await db.requesttrip.create({
+      id: 22,
+      userId: 198,
+      managerId: 198,
+      tripId: 'ae989f24-5878-4736-87dd-a12d797e12f9',
+      status: 'approved',
+    });
+    await db.trips.create({
+      id: 24,
+      tripId: 'ae989f24-5878-4736-87dd-a12d797e12f9',
+      tripType: 'one way',
+      originId: 87,
+      destinationId: 90,
+      userId: 198
+    });
   });
   it('should book an accommodation facility', (done) => {
     chai.request(app).post('/api/v1/accommodations/booking')
       .set('token', `Bearer ${token}`)
       .send({
+        tripId: 24,
         accommodationId: 142,
         roomTypeId: 1,
         departureDate: '2020-04-04',
@@ -107,6 +130,7 @@ describe('Book accommodation Tests', () => {
     chai.request(app).post('/api/v1/accommodations/booking')
       .set('token', `Bearer ${token}`)
       .send({
+        tripId: 24,
         accommodationId: 143,
         roomTypeId: 8,
         departureDate: '2020-04-04',


### PR DESCRIPTION
#### What does this PR do?
This PR adds a functionality to retrieve booking info for only a specific trip request and allow use to remove unlike or like on an accommodation.

#### How should this be manually tested?
- After clone repository, go to the root of the project open path into command run the `npm install` and once setup is done click `npm test`.

- In Postman, create a PATCH request with this url:`http://localhost:3000/api/v1/trips/my-trip-requests` and pass `token` in headers

- In Postman, create a PATCH request with this url:`http://localhost:3000/api/v1/accommodations/{accommodationId}` and pass `token` in headers and in body pass `{ isLike: true || false }`

#### What are the relevant pivotal tracker stories?
- [#171813954](https://www.pivotaltracker.com/story/show/171813954)

#### Screenshots (if appropriate)
<img width="1440" alt="Screen Shot 2020-03-16 at 14 37 36" src="https://user-images.githubusercontent.com/28502544/76760002-8bb67500-6795-11ea-99c0-3fc43f8ea7b6.png">