### PR TITLE
Bug/171926469/correct manager names

### DIFF
--- a/src/controllers/trip.controller.js
+++ b/src/controllers/trip.controller.js
@@ -129,7 +129,7 @@ class TripController {
     const limit = req.query.limit || 10;
     const offset = Paginate(page, limit);
     const requests = await tripService.findTripRequestsById(userId, limit, offset);
-    const manager = await db.user.findOne({ where: requests.managerId });
+    const manager = await tripRequestService.getUserById({ id: requests.rows[0].dataValues.managerId });
     const requestTrips = await tripRequestService.getTripRequestsOfUser(requests, manager);
     return response.successMessage(
       res,
@@ -151,8 +151,9 @@ class TripController {
     const limit = req.query.limit || 10;
     const offset = Paginate(page, limit);
     const requests = await tripService.findTripRequestsByManagerID(managerId, limit, offset);
-    const manager = await db.user.findOne({ where: requests.rows[0].dataValues.userId });
-    const requestTrips = await tripRequestService.getTripRequestsOfUser(requests, manager);
+    const manager = await tripRequestService.getUserById({ id: requests.rows[0].dataValues.managerId });
+    const user = await tripRequestService.getUserById({ id: requests.rows[0].dataValues.userId });
+    const requestTrips = await tripRequestService.getTripRequestsOfUser(requests, manager, user);
     return response.successMessage(
       res,
       'Trips requested by your direct reports',


### PR DESCRIPTION
#### What does this PR do?
this PR comes to correct names of a manager on "get trip requests"
#### Description of Task to be completed?

### Steps to reproduce

1. correct manager names on all trip requests
2. add user names on all trip requests

### Expected

1. to get correct manager names on all trip requests
2. to get correct user names on all trip requests

### Actual

1.  manager names are not correct
2. there is not user names on trip requests

After clone repository goes to the root of the project open path into command run the npm install and once setup is done type npm test.

Using Postman to test endpoints:
after sign in you will get a token
Then
Key: Content-Type value: application/JSON
To test authentication, add this to the header: Bearer

using GET request
visit: URL 1. localhost:3000/api/v1/trip-requests/?page=1&limit=2

#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[#171926469](https://www.pivotaltracker.com/story/show/171926469)
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/47531860/77311507-e78a7c00-6d08-11ea-9d32-b149fa8d5583.png)


#### Questions: